### PR TITLE
Add 'g:worker_global_tasks_file' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ In order to change certain option add `let g:(option name) = '(new value)'` to y
 ### `worker_tasks_file`
 > (default: `'.vim-worker'`)
 
-This option specifies were to read tasks from. You can also specify absolute path in case you want to have one tasks file shared all the time regardless of your current working directory.
+This option specifies were to read tasks from. It is recommended to set relative path for this option - for global tasks file use `worker_global_tasks_file` option.
+
+### `worker_global_tasks_file`
+> (default: none)
+
+This file will be used in case file configured in `worker_tasks_file` is not found.
 
 ### `worker_shortcut_keys`
 > (default: `['a', 's', 'd', 'f', 'j', 'k', 'l', ';', 'w', 'e', 'r', 'u', 'i', 'o', 'p', 'x']`)

--- a/autoload/worker.vim
+++ b/autoload/worker.vim
@@ -4,7 +4,20 @@
 " License:    MIT License
 
 function! worker#ShowTasks()
-    let tasks = s:GetTasks(g:worker_tasks_file, g:worker_shortcut_keys)
+    let tasks_file = ''
+    if exists('g:worker_global_tasks_file') && filereadable(g:worker_global_tasks_file)
+        let tasks_file = g:worker_global_tasks_file
+    endif
+    if filereadable(g:worker_tasks_file)
+        let tasks_file = g:worker_tasks_file
+    endif
+
+    if tasks_file == ''
+        echo 'Vim-Worker: Tasks file not found!'
+        return
+    endif
+
+    let tasks = s:GetTasks(tasks_file, g:worker_shortcut_keys)
     let count = len(tasks)
 
     new


### PR DESCRIPTION
User can now set global tasks file that will be used in case file set in
'g:worker_tasks_file' is not found. In case global file also doesn't
exist (or is not configured) plugin will echo simple message and will
not open tasks list buffer.

See: #2